### PR TITLE
fix(challenge): pass executed query back from XTerminal so Validate works

### DIFF
--- a/src/components/XTerminal.jsx
+++ b/src/components/XTerminal.jsx
@@ -75,7 +75,7 @@ const XTerminal = ({
       } else {
         const table = formatTable(data.columns, data.rows);
         term.write(`\r\n${table}\r\n`);
-        if (onQueryResult) onQueryResult(data);
+        if (onQueryResult) onQueryResult({ ...data, query });
       }
     } catch (err) {
       term.write(`\r\n\x1b[31mERROR: ${err.message}\x1b[0m\r\n`);


### PR DESCRIPTION
## Problem

Solving any challenge fails with a parser error even when the student's SQL is correct:

```
SQL parse error: Expected "!", "#", "$", ... but end of input found
```

The query runs successfully in the terminal and returns the right rows, but clicking **Validate** still errors out.

## Root cause

`src/app/challenges/[id]/page.jsx` tracks `lastQuery` from the terminal callback and submits it to `/api/challenges/[id]/validate`:

```js
const handleTerminalResult = (result) => {
  setQueryResult(result);
  if (result.query) setLastQuery(result.query);   // result.query is always undefined
};

// ...

const validateQuery = async () => {
  const query = lastQuery || sqlQuery;            // falls back to the editor placeholder
  ...
};
```

But `XTerminal.jsx`'s HTTP-fallback handler only forwards the API response (rows + columns), never the query itself:

```js
if (onQueryResult) onQueryResult(data);   // no `query` field
```

So `lastQuery` stays `null` and Validate sends `sqlQuery`, which is the editor placeholder `"-- Write your SQL query here\nSELECT "`. After comment-stripping that's just `SELECT`, which trips `node-sql-parser` with the "end of input found" error.

## Fix

Include the original query in the result payload so the parent can capture it:

```js
if (onQueryResult) onQueryResult({ ...data, query });
```

One-line change. Validate now receives the SQL the student actually ran.

## Test plan

- [ ] Open any challenge, run `SELECT title, published_year FROM books WHERE genre = 'Fiction' ORDER BY title ASC;` in the terminal — terminal shows rows
- [ ] Click **Validate** — passes (no parser error)
- [ ] Run an intentionally wrong query — Validate returns a row-mismatch feedback (not a parse error)
- [ ] Run a query that *is* a parse error (e.g. `SELEC * FROM books`) — Validate surfaces the real parser error