### PR TITLE
feat(admin): configure Anthropic API key from admin panel

### DIFF
--- a/docs/migrations/phase-d-app-settings.sql
+++ b/docs/migrations/phase-d-app-settings.sql
@@ -1,0 +1,12 @@
+-- Phase D — runtime-configurable application settings
+--
+-- Adds a small key/value table used to persist admin-configurable settings
+-- such as the Anthropic API key, so they no longer require a redeploy
+-- to change. Pure additive change, no data migration required.
+
+CREATE TABLE IF NOT EXISTS `AppSetting` (
+  `key`        VARCHAR(191) NOT NULL,
+  `value`      TEXT         NOT NULL,
+  `updated_at` DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (`key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/app/admin/settings/page.jsx
+++ b/src/app/admin/settings/page.jsx
@@ -7,6 +7,7 @@ import {
   SettingsTabs,
   SettingsTabContent,
   GeneralSettingsForm,
+  IntegrationsSettingsForm,
   NotificationsSettingsForm,
   SecuritySettingsForm,
   AppearanceSettingsForm,
@@ -62,6 +63,10 @@ const TAB_HEADINGS = {
   general: {
     title: "Organization settings",
     subtitle: "Settings applied across the entire QueryQuest instance.",
+  },
+  integrations: {
+    title: "Integrations",
+    subtitle: "External services used by QueryQuest, such as the Anthropic API for the in-app AI tutor.",
   },
   notifications: {
     title: "Notification settings",
@@ -188,6 +193,10 @@ export default function AdminSettings() {
             settings={settings}
             onChange={handleSettingChange}
           />
+        </SettingsTabContent>
+
+        <SettingsTabContent value="integrations">
+          <IntegrationsSettingsForm />
         </SettingsTabContent>
 
         <SettingsTabContent value="notifications">

--- a/src/app/api/admin/integrations/route.js
+++ b/src/app/api/admin/integrations/route.js
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server';
+import { getUserFromCookies } from '@/lib/auth-server';
+import { getAppSetting, setAppSetting, maskApiKey } from '@/lib/app-settings';
+
+const ANTHROPIC_KEY = 'anthropic_api_key';
+
+async function requireAdmin(request) {
+  const user = await getUserFromCookies(request.cookies);
+  if (!user || !user.isAdmin) return null;
+  return user;
+}
+
+export async function GET(request) {
+  const admin = await requireAdmin(request);
+  if (!admin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  const stored = await getAppSetting(ANTHROPIC_KEY);
+  const fromEnv = !stored && !!process.env.ANTHROPIC_API_KEY;
+  const effective = stored || (fromEnv ? process.env.ANTHROPIC_API_KEY : '');
+  return NextResponse.json({
+    anthropicApiKey: {
+      configured: !!effective,
+      source: stored ? 'database' : fromEnv ? 'env' : 'none',
+      masked: maskApiKey(effective),
+    },
+  });
+}
+
+export async function PUT(request) {
+  const admin = await requireAdmin(request);
+  if (!admin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const incoming = typeof body?.anthropicApiKey === 'string' ? body.anthropicApiKey.trim() : null;
+  if (incoming === null) {
+    return NextResponse.json({ error: 'anthropicApiKey is required' }, { status: 400 });
+  }
+  if (incoming && !incoming.startsWith('sk-ant-')) {
+    return NextResponse.json(
+      { error: 'Invalid Anthropic API key format (expected to start with sk-ant-)' },
+      { status: 400 }
+    );
+  }
+
+  await setAppSetting(ANTHROPIC_KEY, incoming);
+
+  return NextResponse.json({
+    anthropicApiKey: {
+      configured: !!incoming,
+      source: incoming ? 'database' : 'none',
+      masked: maskApiKey(incoming),
+    },
+  });
+}

--- a/src/components/admin/settings/IntegrationsSettingsForm.jsx
+++ b/src/components/admin/settings/IntegrationsSettingsForm.jsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Eye, EyeOff, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { SettingsFormCard, SettingsFormField } from "./SettingsForm";
+
+/**
+ * Integrations tab — currently exposes the Anthropic API key used by the
+ * in-app Query Quest Assistant chatbot. The key is fetched and saved
+ * directly against /api/admin/integrations (it is not part of the
+ * shared in-memory `settings` state used by the other tabs, because it
+ * needs to actually persist).
+ */
+export function IntegrationsSettingsForm() {
+  const [status, setStatus] = useState({
+    configured: false,
+    source: "none",
+    masked: "",
+  });
+  const [keyInput, setKeyInput] = useState("");
+  const [revealed, setRevealed] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  async function load() {
+    setIsLoading(true);
+    try {
+      const res = await fetch("/api/admin/integrations", {
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setStatus(data.anthropicApiKey);
+    } catch (e) {
+      console.error("Failed to load integrations", e);
+      toast.error("Could not load integrations status");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function save() {
+    setIsSaving(true);
+    try {
+      const res = await fetch("/api/admin/integrations", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ anthropicApiKey: keyInput }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`);
+      setStatus(data.anthropicApiKey);
+      setKeyInput("");
+      toast.success(
+        keyInput
+          ? "Anthropic API key saved. The chatbot is now active."
+          : "Anthropic API key cleared."
+      );
+    } catch (e) {
+      console.error("Failed to save integrations", e);
+      toast.error(e.message || "Failed to save API key");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <SettingsFormCard
+      title="Anthropic (Query Quest Assistant)"
+      description="Configure the API key used by the in-app AI tutor. Get a key at console.anthropic.com."
+    >
+      <SettingsFormField
+        label="Status"
+        description="Where the active key currently comes from"
+      >
+        {isLoading ? (
+          <div className="flex items-center gap-2 text-sm text-gray-500">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Checking…
+          </div>
+        ) : status.configured ? (
+          <div className="flex flex-col gap-1">
+            <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-green-50 border border-green-200 px-2.5 py-1 text-[12px] font-semibold text-green-700">
+              <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
+              Configured · {status.source === "database" ? "from admin panel" : "from environment"}
+            </span>
+            <span className="font-mono text-xs text-gray-500">{status.masked}</span>
+          </div>
+        ) : (
+          <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-amber-50 border border-amber-200 px-2.5 py-1 text-[12px] font-semibold text-amber-700">
+            <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+            Not configured · chatbot disabled
+          </span>
+        )}
+      </SettingsFormField>
+
+      <SettingsFormField
+        label="API key"
+        description="Starts with sk-ant-. Leave empty and save to remove the stored key."
+      >
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <input
+              type={revealed ? "text" : "password"}
+              value={keyInput}
+              onChange={(e) => setKeyInput(e.target.value)}
+              placeholder="sk-ant-…"
+              autoComplete="off"
+              spellCheck={false}
+              className="w-full pl-3.5 pr-10 py-2.5 text-sm text-[#030914] font-medium bg-white border border-gray-300 rounded-lg focus:outline-none focus:border-[#19aa59] focus:ring-2 focus:ring-[#19aa59]/20 font-mono"
+            />
+            <button
+              type="button"
+              onClick={() => setRevealed((v) => !v)}
+              aria-label={revealed ? "Hide API key" : "Show API key"}
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 text-gray-500 hover:text-[#030914]"
+            >
+              {revealed ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={save}
+            disabled={isSaving || isLoading}
+            className="inline-flex items-center justify-center gap-2 rounded-lg bg-[#19aa59] hover:bg-[#15934d] px-4 py-2.5 text-[13px] font-bold text-white disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {isSaving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            {isSaving ? "Saving…" : "Save key"}
+          </button>
+        </div>
+      </SettingsFormField>
+    </SettingsFormCard>
+  );
+}

--- a/src/components/admin/settings/SettingsTabs.jsx
+++ b/src/components/admin/settings/SettingsTabs.jsx
@@ -8,10 +8,12 @@ import {
   Palette,
   Database,
   Users,
+  Sparkles,
 } from "lucide-react";
 
 const tabs = [
   { id: "general", label: "General", icon: Settings },
+  { id: "integrations", label: "Integrations", icon: Sparkles },
   { id: "notifications", label: "Notifications", icon: Bell },
   { id: "security", label: "Security", icon: Shield },
   { id: "appearance", label: "Appearance", icon: Palette },

--- a/src/components/admin/settings/index.js
+++ b/src/components/admin/settings/index.js
@@ -10,3 +10,4 @@ export {
   UsersSettingsForm,
   SystemSettingsForm,
 } from "./SettingsForm";
+export { IntegrationsSettingsForm } from "./IntegrationsSettingsForm";

--- a/src/lib/anthropic-service.js
+++ b/src/lib/anthropic-service.js
@@ -1,33 +1,42 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { CHAT_CONFIG } from '../config/chat-config.js';
+import { getAppSetting } from './app-settings.js';
 
 class AnthropicService {
   constructor() {
     this.client = null;
-    this.initialized = false;
+    this.apiKeyInUse = null;
   }
 
   /**
-   * Initialize the Anthropic client
-   * @returns {boolean} - Whether initialization was successful
+   * Initialize (or re-initialize) the Anthropic client.
+   *
+   * The key is resolved at call time from the AppSetting table, falling
+   * back to the ANTHROPIC_API_KEY env var. The client is re-created if
+   * the active key changes (admin rotation), so updates from the admin
+   * panel take effect without a redeploy.
+   *
+   * @returns {Promise<boolean>} - Whether the client is ready.
    */
-  initialize() {
-    if (this.initialized) return true;
-
-    const apiKey = CHAT_CONFIG.ANTHROPIC_API_KEY;
+  async initialize() {
+    const apiKey = await getAppSetting('anthropic_api_key', {
+      envFallback: 'ANTHROPIC_API_KEY',
+    });
     if (!apiKey) {
-      console.error('Anthropic API key not configured. Please set ANTHROPIC_API_KEY in your environment variables.');
+      console.error('Anthropic API key not configured. Set it from the admin panel (Integrations) or via ANTHROPIC_API_KEY.');
+      this.client = null;
+      this.apiKeyInUse = null;
       return false;
     }
-
+    if (this.client && this.apiKeyInUse === apiKey) return true;
     try {
-      this.client = new Anthropic({
-        apiKey: apiKey,
-      });
-      this.initialized = true;
+      this.client = new Anthropic({ apiKey });
+      this.apiKeyInUse = apiKey;
       return true;
     } catch (error) {
       console.error('Failed to initialize Anthropic client:', error);
+      this.client = null;
+      this.apiKeyInUse = null;
       return false;
     }
   }
@@ -41,7 +50,7 @@ class AnthropicService {
    */
   async generateResponse(userMessage, conversationHistory = [], contextData = {}) {
     // Initialize client if not already done
-    if (!this.initialize()) {
+    if (!(await this.initialize())) {
       return "I'm sorry, but my AI service is not properly configured. Please contact your administrator to set up the Anthropic API key.";
     }
 

--- a/src/lib/app-settings.js
+++ b/src/lib/app-settings.js
@@ -1,0 +1,45 @@
+/**
+ * Runtime-configurable application settings, persisted in the AppSetting
+ * key/value table. Falls back to environment variables when a key is not
+ * set in the database, so existing `.env` deployments keep working.
+ *
+ * Cached in memory with a short TTL to avoid hammering the DB on every
+ * chat request; cache is invalidated on writes.
+ */
+
+import { prisma } from './prisma';
+
+const CACHE_TTL_MS = 30_000;
+const cache = new Map(); // key -> { value, expiresAt }
+
+export async function getAppSetting(key, { envFallback } = {}) {
+  const cached = cache.get(key);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value ?? (envFallback ? process.env[envFallback] || '' : '');
+  }
+  let value = '';
+  try {
+    const row = await prisma.appSetting.findUnique({ where: { key } });
+    value = row?.value || '';
+  } catch {
+    value = '';
+  }
+  cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+  if (!value && envFallback) return process.env[envFallback] || '';
+  return value;
+}
+
+export async function setAppSetting(key, value) {
+  await prisma.appSetting.upsert({
+    where: { key },
+    update: { value },
+    create: { key, value },
+  });
+  cache.delete(key);
+}
+
+export function maskApiKey(key) {
+  if (!key) return '';
+  if (key.length <= 8) return '••••';
+  return `${key.slice(0, 7)}••••${key.slice(-4)}`;
+}

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -279,3 +279,9 @@ model QueryAttempt {
   @@index([user_id])
   @@index([challenge_id])
 }
+
+model AppSetting {
+  key        String   @id
+  value      String   @db.Text
+  updated_at DateTime @default(now()) @updatedAt
+}


### PR DESCRIPTION
## Summary

Moves the Anthropic API key from the environment variable `ANTHROPIC_API_KEY` into a runtime-configurable setting persisted in the database, so administrators can rotate it from `/admin/settings → Integrations` without a redeploy. The env var keeps working as a fallback, so existing deployments are unaffected until an admin overrides the value.

The chatbot is currently disabled in production because no key is set; this PR exposes a path to configure one through the UI.

## What changes

**Backend**
- New `AppSetting` model (`key`/`value`/`updated_at`) in `schema.prisma` and `docs/migrations/phase-d-app-settings.sql` for production (matches the existing `phase-X` convention).
- `lib/app-settings.js` — small key/value helper with a 30 s in-memory cache and env-var fallback.
- `PUT/GET /api/admin/integrations` — admin-only route. `GET` returns `{ configured, source: "database" | "env" | "none", masked }`. `PUT` validates the `sk-ant-` prefix and upserts. The raw key never leaves the server.
- `lib/anthropic-service.js` — `initialize()` is now async and resolves the key per call; the Anthropic client is rebuilt when the active key changes, so admin updates take effect on the next chat request.

**Frontend**
- New **Integrations** tab in `/admin/settings` (Sparkles icon).
- `IntegrationsSettingsForm`: status badge (configured + source + masked preview), password-style input with reveal toggle, Save button. Saving an empty value clears the stored key (falls back to env if set, otherwise disables the chatbot).

## Rollout

1. Apply `docs/migrations/phase-d-app-settings.sql` against the production MySQL instance (or `npx prisma db push` from a deploy with DB access).
2. Deploy. Existing `ANTHROPIC_API_KEY` env var continues to work.
3. In `/admin/settings → Integrations`, paste the key and Save. Optionally remove it from the environment afterwards.

## Test plan

- [ ] Apply the SQL migration in a sandbox DB and run `npx prisma generate` so the client picks up `AppSetting`.
- [ ] As a non-admin user, `GET /api/admin/integrations` returns 403.
- [ ] As an admin, `GET` reports `source: "env"` when only the env var is set, and `source: "database"` after a successful `PUT`.
- [ ] `PUT` rejects keys that do not start with `sk-ant-` with 400.
- [ ] After saving a valid key in the UI, opening the chatbot on a challenge produces a real response (no more "AI service is not properly configured" message), without redeploying.
- [ ] Saving an empty value falls back to the env var if present, or disables the chatbot otherwise.
- [ ] Rotating the key from the panel takes effect on the next message (the `apiKeyInUse` check in `AnthropicService.initialize` triggers a reinit).