### PR TITLE
fix(chatbot): use current Claude model by default and let admins pick

### DIFF
--- a/src/app/api/admin/integrations/route.js
+++ b/src/app/api/admin/integrations/route.js
@@ -1,8 +1,11 @@
 import { NextResponse } from 'next/server';
 import { getUserFromCookies } from '@/lib/auth-server';
 import { getAppSetting, setAppSetting, maskApiKey } from '@/lib/app-settings';
+import { CHAT_CONFIG } from '@/config/chat-config';
+import anthropicService from '@/lib/anthropic-service';
 
 const ANTHROPIC_KEY = 'anthropic_api_key';
+const ANTHROPIC_MODEL_KEY = 'anthropic_model';
 
 async function requireAdmin(request) {
   const user = await getUserFromCookies(request.cookies);
@@ -10,21 +13,36 @@ async function requireAdmin(request) {
   return user;
 }
 
+async function buildState() {
+  const storedKey = await getAppSetting(ANTHROPIC_KEY);
+  const fromEnvKey = !storedKey && !!process.env.ANTHROPIC_API_KEY;
+  const effectiveKey = storedKey || (fromEnvKey ? process.env.ANTHROPIC_API_KEY : '');
+
+  const storedModel = await getAppSetting(ANTHROPIC_MODEL_KEY);
+  const fromEnvModel = !storedModel && !!process.env.ANTHROPIC_MODEL;
+  const effectiveModel =
+    storedModel || (fromEnvModel ? process.env.ANTHROPIC_MODEL : CHAT_CONFIG.ANTHROPIC_MODEL);
+
+  return {
+    anthropicApiKey: {
+      configured: !!effectiveKey,
+      source: storedKey ? 'database' : fromEnvKey ? 'env' : 'none',
+      masked: maskApiKey(effectiveKey),
+    },
+    anthropicModel: {
+      value: effectiveModel,
+      source: storedModel ? 'database' : fromEnvModel ? 'env' : 'default',
+      available: anthropicService.getAvailableModels(),
+    },
+  };
+}
+
 export async function GET(request) {
   const admin = await requireAdmin(request);
   if (!admin) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
-  const stored = await getAppSetting(ANTHROPIC_KEY);
-  const fromEnv = !stored && !!process.env.ANTHROPIC_API_KEY;
-  const effective = stored || (fromEnv ? process.env.ANTHROPIC_API_KEY : '');
-  return NextResponse.json({
-    anthropicApiKey: {
-      configured: !!effective,
-      source: stored ? 'database' : fromEnv ? 'env' : 'none',
-      masked: maskApiKey(effective),
-    },
-  });
+  return NextResponse.json(await buildState());
 }
 
 export async function PUT(request) {
@@ -40,24 +58,28 @@ export async function PUT(request) {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
-  const incoming = typeof body?.anthropicApiKey === 'string' ? body.anthropicApiKey.trim() : null;
-  if (incoming === null) {
-    return NextResponse.json({ error: 'anthropicApiKey is required' }, { status: 400 });
-  }
-  if (incoming && !incoming.startsWith('sk-ant-')) {
-    return NextResponse.json(
-      { error: 'Invalid Anthropic API key format (expected to start with sk-ant-)' },
-      { status: 400 }
-    );
+  if (typeof body?.anthropicApiKey === 'string') {
+    const incoming = body.anthropicApiKey.trim();
+    if (incoming && !incoming.startsWith('sk-ant-')) {
+      return NextResponse.json(
+        { error: 'Invalid Anthropic API key format (expected to start with sk-ant-)' },
+        { status: 400 }
+      );
+    }
+    await setAppSetting(ANTHROPIC_KEY, incoming);
   }
 
-  await setAppSetting(ANTHROPIC_KEY, incoming);
+  if (typeof body?.anthropicModel === 'string') {
+    const incoming = body.anthropicModel.trim();
+    const allowed = new Set(anthropicService.getAvailableModels().map((m) => m.id));
+    if (incoming && !allowed.has(incoming)) {
+      return NextResponse.json(
+        { error: `Unknown model. Allowed: ${[...allowed].join(', ')}` },
+        { status: 400 }
+      );
+    }
+    await setAppSetting(ANTHROPIC_MODEL_KEY, incoming);
+  }
 
-  return NextResponse.json({
-    anthropicApiKey: {
-      configured: !!incoming,
-      source: incoming ? 'database' : 'none',
-      masked: maskApiKey(incoming),
-    },
-  });
+  return NextResponse.json(await buildState());
 }

--- a/src/components/admin/settings/IntegrationsSettingsForm.jsx
+++ b/src/components/admin/settings/IntegrationsSettingsForm.jsx
@@ -6,22 +6,28 @@ import { toast } from "sonner";
 import { SettingsFormCard, SettingsFormField } from "./SettingsForm";
 
 /**
- * Integrations tab — currently exposes the Anthropic API key used by the
- * in-app Query Quest Assistant chatbot. The key is fetched and saved
- * directly against /api/admin/integrations (it is not part of the
- * shared in-memory `settings` state used by the other tabs, because it
- * needs to actually persist).
+ * Integrations tab — currently exposes the Anthropic API key and model
+ * used by the in-app Query Quest Assistant chatbot. The form fetches
+ * and saves directly against /api/admin/integrations rather than going
+ * through the shared in-memory `settings` state used by the other tabs,
+ * because these values need to actually persist.
  */
 export function IntegrationsSettingsForm() {
-  const [status, setStatus] = useState({
+  const [keyStatus, setKeyStatus] = useState({
     configured: false,
     source: "none",
     masked: "",
   });
+  const [model, setModel] = useState({
+    value: "",
+    source: "default",
+    available: [],
+  });
   const [keyInput, setKeyInput] = useState("");
   const [revealed, setRevealed] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-  const [isSaving, setIsSaving] = useState(false);
+  const [isSavingKey, setIsSavingKey] = useState(false);
+  const [isSavingModel, setIsSavingModel] = useState(false);
 
   useEffect(() => {
     void load();
@@ -35,7 +41,8 @@ export function IntegrationsSettingsForm() {
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
-      setStatus(data.anthropicApiKey);
+      setKeyStatus(data.anthropicApiKey);
+      setModel(data.anthropicModel);
     } catch (e) {
       console.error("Failed to load integrations", e);
       toast.error("Could not load integrations status");
@@ -44,8 +51,8 @@ export function IntegrationsSettingsForm() {
     }
   }
 
-  async function save() {
-    setIsSaving(true);
+  async function saveKey() {
+    setIsSavingKey(true);
     try {
       const res = await fetch("/api/admin/integrations", {
         method: "PUT",
@@ -55,7 +62,7 @@ export function IntegrationsSettingsForm() {
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`);
-      setStatus(data.anthropicApiKey);
+      setKeyStatus(data.anthropicApiKey);
       setKeyInput("");
       toast.success(
         keyInput
@@ -63,17 +70,38 @@ export function IntegrationsSettingsForm() {
           : "Anthropic API key cleared."
       );
     } catch (e) {
-      console.error("Failed to save integrations", e);
+      console.error("Failed to save API key", e);
       toast.error(e.message || "Failed to save API key");
     } finally {
-      setIsSaving(false);
+      setIsSavingKey(false);
+    }
+  }
+
+  async function saveModel(newModel) {
+    setIsSavingModel(true);
+    try {
+      const res = await fetch("/api/admin/integrations", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ anthropicModel: newModel }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`);
+      setModel(data.anthropicModel);
+      toast.success(`Chatbot model set to ${newModel}.`);
+    } catch (e) {
+      console.error("Failed to save model", e);
+      toast.error(e.message || "Failed to save model");
+    } finally {
+      setIsSavingModel(false);
     }
   }
 
   return (
     <SettingsFormCard
       title="Anthropic (Query Quest Assistant)"
-      description="Configure the API key used by the in-app AI tutor. Get a key at console.anthropic.com."
+      description="Configure the API key and model used by the in-app AI tutor. Get a key at console.anthropic.com."
     >
       <SettingsFormField
         label="Status"
@@ -84,13 +112,13 @@ export function IntegrationsSettingsForm() {
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
             Checking…
           </div>
-        ) : status.configured ? (
+        ) : keyStatus.configured ? (
           <div className="flex flex-col gap-1">
             <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-green-50 border border-green-200 px-2.5 py-1 text-[12px] font-semibold text-green-700">
               <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
-              Configured · {status.source === "database" ? "from admin panel" : "from environment"}
+              Configured · {keyStatus.source === "database" ? "from admin panel" : "from environment"}
             </span>
-            <span className="font-mono text-xs text-gray-500">{status.masked}</span>
+            <span className="font-mono text-xs text-gray-500">{keyStatus.masked}</span>
           </div>
         ) : (
           <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-amber-50 border border-amber-200 px-2.5 py-1 text-[12px] font-semibold text-amber-700">
@@ -126,13 +154,41 @@ export function IntegrationsSettingsForm() {
           </div>
           <button
             type="button"
-            onClick={save}
-            disabled={isSaving || isLoading}
+            onClick={saveKey}
+            disabled={isSavingKey || isLoading}
             className="inline-flex items-center justify-center gap-2 rounded-lg bg-[#19aa59] hover:bg-[#15934d] px-4 py-2.5 text-[13px] font-bold text-white disabled:opacity-60 disabled:cursor-not-allowed"
           >
-            {isSaving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-            {isSaving ? "Saving…" : "Save key"}
+            {isSavingKey && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            {isSavingKey ? "Saving…" : "Save key"}
           </button>
+        </div>
+      </SettingsFormField>
+
+      <SettingsFormField
+        label="Model"
+        description={
+          isLoading
+            ? "Loading…"
+            : `Currently active: ${model.value} · source: ${model.source}`
+        }
+      >
+        <div className="flex gap-2 items-center">
+          <select
+            value={model.value}
+            onChange={(e) => saveModel(e.target.value)}
+            disabled={isSavingModel || isLoading}
+            className="flex-1 px-3.5 py-2.5 text-sm text-[#030914] font-medium bg-white border border-gray-300 rounded-lg focus:outline-none focus:border-[#19aa59] focus:ring-2 focus:ring-[#19aa59]/20 disabled:opacity-60"
+          >
+            {model.available.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.label}
+              </option>
+            ))}
+            {model.value && !model.available.some((m) => m.id === model.value) && (
+              <option value={model.value}>{model.value} (custom)</option>
+            )}
+          </select>
+          {isSavingModel && <Loader2 className="h-4 w-4 animate-spin text-gray-500" />}
         </div>
       </SettingsFormField>
     </SettingsFormCard>

--- a/src/config/chat-config.js
+++ b/src/config/chat-config.js
@@ -4,7 +4,10 @@
 export const CHAT_CONFIG = {
   // Anthropic Configuration
   ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY || '',
-  ANTHROPIC_MODEL: process.env.ANTHROPIC_MODEL || 'claude-3-5-sonnet-20241022',
+  // Default to Haiku 4.5 — cheapest current Claude model, ample for SQL Q&A.
+  // Admins can override per-instance from /admin/settings → Integrations,
+  // or globally with the ANTHROPIC_MODEL environment variable.
+  ANTHROPIC_MODEL: process.env.ANTHROPIC_MODEL || 'claude-haiku-4-5-20251001',
   ANTHROPIC_MAX_TOKENS: parseInt(process.env.ANTHROPIC_MAX_TOKENS) || 1000,
   ANTHROPIC_TEMPERATURE: parseFloat(process.env.ANTHROPIC_TEMPERATURE) || 0.7,
 

--- a/src/lib/anthropic-service.js
+++ b/src/lib/anthropic-service.js
@@ -64,8 +64,12 @@ class AnthropicService {
         { role: 'user', content: userMessage }
       ];
 
+      const model = await getAppSetting('anthropic_model', {
+        envFallback: 'ANTHROPIC_MODEL',
+      }) || CHAT_CONFIG.ANTHROPIC_MODEL;
+
       const response = await this.client.messages.create({
-        model: CHAT_CONFIG.ANTHROPIC_MODEL,
+        model,
         max_tokens: CHAT_CONFIG.ANTHROPIC_MAX_TOKENS,
         temperature: CHAT_CONFIG.ANTHROPIC_TEMPERATURE,
         system: systemPrompt,
@@ -220,11 +224,9 @@ Dont get pitty of people who ask for the answer. They are learning and you are h
    */
   getAvailableModels() {
     return [
-      'claude-3-5-sonnet-20241022',
-      'claude-3-5-haiku-20241022',
-      'claude-3-opus-20240229',
-      'claude-3-sonnet-20240229',
-      'claude-3-haiku-20240307'
+      { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5 — fastest & cheapest (recommended)' },
+      { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6 — better quality, higher cost' },
+      { id: 'claude-opus-4-7', label: 'Opus 4.7 — top quality, highest cost' },
     ];
   }
 }


### PR DESCRIPTION
## Summary

The previous default model `claude-3-5-sonnet-20241022` is no longer served by the Anthropic API for new accounts, so even after a valid key is configured the chatbot replies with `404 not_found_error`. Production logs from this morning showed exactly that:

> Anthropic API Error: Error: 404 {"type":"error","error":{"type":"not_found_error","message":"model: claude-3-5-sonnet-20241022"}}

This PR switches the default to `claude-haiku-4-5-20251001` (cheapest current Claude model — plenty for SQL Q&A) and exposes the choice from the admin panel so the same person who configures the key can also pick the model.

## Changes

- `chat-config.js` — default model is now `claude-haiku-4-5-20251001`. `ANTHROPIC_MODEL` env var still wins.
- `anthropic-service.js` — `generateResponse` resolves the model per call via `getAppSetting('anthropic_model')`, so changing it in the UI takes effect on the next message. `getAvailableModels()` now returns `{id, label}` objects with the current Haiku 4.5 / Sonnet 4.6 / Opus 4.7 IDs (the old list of dead IDs is gone).
- `/api/admin/integrations` — reports the active model along with the API key, including its source (`database` / `env` / `default`). `PUT` validates against the allowed list.
- `IntegrationsSettingsForm` — adds a Model dropdown next to the API key field. Saving auto-applies on change.

No schema change — `AppSetting` already supports the new `anthropic_model` key.

## Test plan

- [ ] After deploy, `/admin/settings → Integrations` shows the existing key (still configured) plus a Model dropdown defaulting to Haiku 4.5.
- [ ] Asking the chatbot on a challenge produces a real response (no more 404).
- [ ] Switching the dropdown to Sonnet 4.6 and asking again uses the new model on the next request (verifiable in Railway logs).
- [ ] `PUT /api/admin/integrations` with a model not in the allowed list returns 400.