### PR TITLE
fix(chatbot): pass challenge UUID as context, not nothing

### DIFF
--- a/src/hooks/usePageContext.js
+++ b/src/hooks/usePageContext.js
@@ -148,22 +148,27 @@ export function usePageContext() {
 }
 
 /**
- * Helper function to extract ID from pathname
+ * Helper function to extract an entity ID from the pathname.
+ *
+ * Challenge and lesson IDs in this app are UUIDs (e.g.
+ * "07f89c63-0cb6-4c87-8c02-f106c196abe6"), not numeric, so we cannot
+ * gate on `/^\d+$/`. We accept any path segment immediately after the
+ * named segment that is not itself a well-known sub-route (so
+ * `/challenges/new` → null, but `/challenges/<uuid>` → the uuid, and
+ * `/challenges/<uuid>/edit` → still the uuid).
+ *
  * @param {string} pathname - Current pathname
  * @param {string} segment - The segment to look for (e.g., 'challenges', 'lessons')
  * @returns {string|null} - Extracted ID or null
  */
+const RESERVED_SUBROUTES = new Set(['new', 'edit', 'create', 'bulk', 'bulk-delete', 'stats']);
+
 function extractIdFromPath(pathname, segment) {
-  const parts = pathname.split('/');
-  const segmentIndex = parts.findIndex(part => part === segment);
-  
-  if (segmentIndex !== -1 && segmentIndex + 1 < parts.length) {
-    const potentialId = parts[segmentIndex + 1];
-    // Check if it's a valid ID (numeric or contains numbers)
-    if (/^\d+$/.test(potentialId)) {
-      return potentialId;
-    }
-  }
-  
-  return null;
+  const parts = pathname.split('/').filter(Boolean);
+  const segmentIndex = parts.findIndex((part) => part === segment);
+  if (segmentIndex === -1 || segmentIndex + 1 >= parts.length) return null;
+
+  const candidate = parts[segmentIndex + 1];
+  if (!candidate || RESERVED_SUBROUTES.has(candidate)) return null;
+  return candidate;
 }


### PR DESCRIPTION
## Summary

Asking the chatbot for help on \`/challenges/07f89c63-0cb6-4c87-8c02-f106c196abe6\` produces a generic "I see you have 3 challenges available, which one are you on?" reply, even though the URL clearly identifies the challenge. The user has to paste the challenge name back into chat for the assistant to do anything useful.

Root cause: \`usePageContext\` validates the path segment after \`/challenges/\` with \`/^\d+$/\`, accepting only numeric IDs. The app uses UUIDs, so the regex always rejects the ID, the hook returns \`{ type: 'challenges' }\` (the generic listing context) instead of \`{ type: 'challenge', challengeId: '07f89c63-…' }\`, and \`/api/chat\` never loads the challenge into \`specificContext\`. The system prompt never sees which challenge the user is on.

## Change

Drop the shape-based validation. Accept any segment that follows \`/challenges/\` or \`/lessons/\`, except a small reserved list of known sibling routes (\`new\`, \`edit\`, \`create\`, \`bulk\`, \`bulk-delete\`, \`stats\`).

| URL | Before | After |
|---|---|---|
| \`/challenges\` | listing | listing |
| \`/challenges/new\` | listing (wrong) | listing (still safe) |
| \`/challenges/<uuid>\` | listing (wrong) | challenge detail with id |
| \`/challenges/<uuid>/edit\` | listing (wrong) | challenge detail with id |
| \`/lessons/<uuid>\` | listing (wrong) | lesson detail with id |

The rest of the file is untouched. The chat route already knows what to do with a present \`challengeId\` / \`lessonId\` (loads the challenge or lesson and adds it to the prompt), so this one-file fix makes contextual help work end-to-end on the production schema.

## Test plan

- [ ] Open \`/challenges/<some-uuid>\` and ask "ayudame con este ejercicio" — the assistant talks about *that* challenge specifically (its statement, its tables) without first asking which one.
- [ ] Open \`/lessons/<some-uuid>\` and ask a question — the assistant uses the lesson context.
- [ ] Open \`/challenges\` (listing) and ask a question — the assistant gets the generic listing context as before.
- [ ] Visit \`/admin/challenges/<uuid>/edit\` — the chatbot context still correctly resolves to that challenge.