### PR TITLE
feat(challenges): scope validation panel to Validate, add terminal history

### DIFF
--- a/src/app/challenges/[id]/_components/QueryResults.jsx
+++ b/src/app/challenges/[id]/_components/QueryResults.jsx
@@ -4,14 +4,14 @@ export function QueryResults({ queryResult, queryError }) {
   if (!queryResult && !queryError) return null;
 
   return (
-    <div className="bg-[#0a1628] border-t border-gray-800">
+    <div className="bg-[#0a1628] border-t border-gray-800 flex-shrink-0">
       <div className="px-4 py-2 border-b border-gray-800">
         <h3 className="font-medium text-[#19aa59] text-sm flex items-center gap-2">
           <Target className="h-4 w-4" />
-          Query Results
+          Validation Result
         </h3>
       </div>
-      <div className="p-4 max-h-64 overflow-y-auto">
+      <div className="p-4 max-h-48 overflow-y-auto">
         {queryError && (
           <div className="bg-red-500/10 border border-red-500/30 rounded-xl p-4">
             <div className="flex items-center gap-2 text-red-400 mb-2">

--- a/src/app/challenges/[id]/page.jsx
+++ b/src/app/challenges/[id]/page.jsx
@@ -175,15 +175,18 @@ export default function ChallengeDetail() {
     }
   };
 
+  // Terminal events only feed the Validate button (lastQuery) and challenge
+  // completion. The QueryResults panel is reserved for explicit Validate
+  // clicks — running ad-hoc queries (DESCRIBE, SHOW TABLES, …) shouldn't
+  // surface a "Try Again" message.
   const handleTerminalResult = (result) => {
-    setQueryResult(result);
     if (result.query) setLastQuery(result.query);
     if (result.success && result.type === "challenge_completed") {
       setIsCompleted(true);
     }
   };
 
-  const handleTerminalError = (err) => setQueryError(err.error);
+  const handleTerminalError = () => {};
 
   if (loading) return <LoadingState />;
   if (error || !challenge) return <NotFoundState error={error} />;

--- a/src/components/XTerminal.jsx
+++ b/src/components/XTerminal.jsx
@@ -44,6 +44,11 @@ const XTerminal = ({
   const fitAddonRef = useRef(null);
   const inputBufferRef = useRef('');
   const modeRef = useRef(null); // 'ws' or 'api'
+  // Shell-style history. historyIndex points at the slot the user is viewing;
+  // historyIndex === history.length means "fresh line" (the in-progress draft).
+  const historyRef = useRef([]);
+  const historyIndexRef = useRef(0);
+  const draftRef = useRef('');
   const [isConnected, setIsConnected] = useState(false);
   const [fontSize, setFontSize] = useState(14);
 
@@ -90,6 +95,12 @@ const XTerminal = ({
     term.write(`\x1b[38;2;148;163;184mDatabase: ${databaseName} | Read-only mode\x1b[0m\r\n\r\n`);
     term.write('mysql> ');
 
+    const replaceInputLine = (value) => {
+      // Clear the current line and redraw the prompt with `value` as input.
+      term.write('\r\x1b[2Kmysql> ' + value);
+      inputBufferRef.current = value;
+    };
+
     term.onData((data) => {
       if (modeRef.current !== 'api') return;
 
@@ -98,9 +109,37 @@ const XTerminal = ({
         inputBufferRef.current = '';
         term.write('\r\n');
         if (query) {
+          const last = historyRef.current[historyRef.current.length - 1];
+          if (last !== query) {
+            historyRef.current.push(query);
+            if (historyRef.current.length > 100) historyRef.current.shift();
+          }
+          historyIndexRef.current = historyRef.current.length;
+          draftRef.current = '';
           executeViaAPI(query, term);
         } else {
+          historyIndexRef.current = historyRef.current.length;
+          draftRef.current = '';
           term.write('mysql> ');
+        }
+      } else if (data === '\x1b[A' || data === '\x1bOA') {
+        // Up arrow — walk backward through history.
+        if (historyRef.current.length === 0) return;
+        if (historyIndexRef.current === historyRef.current.length) {
+          draftRef.current = inputBufferRef.current;
+        }
+        if (historyIndexRef.current > 0) {
+          historyIndexRef.current -= 1;
+          replaceInputLine(historyRef.current[historyIndexRef.current]);
+        }
+      } else if (data === '\x1b[B' || data === '\x1bOB') {
+        // Down arrow — walk forward; falling off the end restores the draft.
+        if (historyIndexRef.current >= historyRef.current.length) return;
+        historyIndexRef.current += 1;
+        if (historyIndexRef.current === historyRef.current.length) {
+          replaceInputLine(draftRef.current);
+        } else {
+          replaceInputLine(historyRef.current[historyIndexRef.current]);
         }
       } else if (data === '\x7f' || data === '\b') {
         if (inputBufferRef.current.length > 0) {
@@ -109,6 +148,8 @@ const XTerminal = ({
         }
       } else if (data === '\x03') {
         inputBufferRef.current = '';
+        historyIndexRef.current = historyRef.current.length;
+        draftRef.current = '';
         term.write('^C\r\nmysql> ');
       } else if (data >= ' ') {
         inputBufferRef.current += data;
@@ -206,6 +247,14 @@ const XTerminal = ({
     };
     window.addEventListener('resize', handleResize);
 
+    // Refit when the container itself resizes (e.g., the QueryResults panel
+    // appearing/disappearing below). Window-level resize alone misses these.
+    let resizeObserver = null;
+    if (typeof ResizeObserver !== 'undefined' && terminalRef.current) {
+      resizeObserver = new ResizeObserver(handleResize);
+      resizeObserver.observe(terminalRef.current);
+    }
+
     // Skip the WebSocket attempt entirely — it's never up in this
     // environment and the connection-refused noise drowns the console.
     // The HTTP path through /api/shell is the canonical transport.
@@ -213,6 +262,7 @@ const XTerminal = ({
 
     return () => {
       window.removeEventListener('resize', handleResize);
+      if (resizeObserver) { resizeObserver.disconnect(); resizeObserver = null; }
       if (socketRef.current) { socketRef.current.close(); socketRef.current = null; }
       if (term) term.dispose();
     };
@@ -255,7 +305,6 @@ const XTerminal = ({
           backgroundColor: '#030914',
           fontFamily: 'Menlo, Monaco, "Courier New", monospace',
           fontSize: `${fontSize}px`,
-          minHeight: '400px'
         }}
       />
 


### PR DESCRIPTION
## Summary
- Terminal Enter no longer pops the QueryResults panel — ad-hoc commands like `DESCRIBE tables` or `SHOW TABLES` stay inline. The panel only opens on explicit Validate clicks and is renamed "Validation Result".
- Removed the 400px min-height on the inner XTerminal div that was preventing the flex parent from shrinking, and added a ResizeObserver so xterm refits when the result panel toggles below it.
- Added shell-style command history to the XTerminal with Up/Down arrow recall, draft preservation, dedupe against the previous entry, and a 100-entry cap.

## Test plan
- [ ] Open a challenge `/challenges/<id>`. Type `DESCRIBE …`, `SHOW TABLES`, or a deliberate syntax error and press Enter. Confirm no "Try Again" / "Query Error" panel appears below.
- [ ] Run a query, click **Validate**, and confirm the "Validation Result" panel appears with the correct success/failure feedback.
- [ ] Toggle the validation panel by repeatedly validating; confirm the terminal canvas resizes correctly and scroll feels normal.
- [ ] In the terminal, run a few queries, then press Up/Down to walk through history. Confirm the in-progress draft is restored when stepping past the latest entry.
- [ ] Press Ctrl+C mid-input and confirm the history pointer resets to a fresh prompt.